### PR TITLE
Add Amazon US to the list of domains in order to block Xray properly

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "content_scripts": [
     {
       "js": ["content.js"],
-      "matches": ["https://www.primevideo.com/*", "https://www.amazon.co.uk/*video*"]
+      "matches": ["https://www.primevideo.com/*", "https://www.amazon.co.uk/*video*", "https://www.amazon.com/gp/video/*"]
     }
   ]
 }


### PR DESCRIPTION
Without this, Xray still is showing on the Amazon Prime Video US site even with this extension installed.